### PR TITLE
Updated to latest jsdom, changed html-md to Europa

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,12 +2,15 @@
 var scrape = require('../index.js').scrape,
     optimist = require('optimist'),
     argv = optimist
-            .usage('Usage: $0 -h -s [selector] [url|file|html]...')
+            .usage('Usage: $0 -h -s [selector] -i [url|file|html]...')
             .boolean('h')
             .alias('h', 'help')
             .describe('h', 'Display usage')
             .alias('s', 'selector')
             .describe('s', 'Scrape HTML from each page using this selector')
+            .boolean('i')
+            .alias('i', 'inline')
+            .describe('i', 'If set, anchor/image URLs are to be inserted inline')
             .argv;
 
 function readStdin() {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var url = require('url'),
     jsdom = require("jsdom/lib/old-api.js"),
     Europa = require('node-europa'),
-    europa = new Europa(),
+    europa = null,
     config = {};
 
 // TODO make user-configurable
@@ -31,7 +31,7 @@ function parseDOM(data) {
 
 function scrape(argv, data) {
     config.selector = argv.selector || 'body';
-
+    europa = new Europa({inline: argv.inline});
     if (data) {
         parseDOM(data);
     } else {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var url = require('url'),
-    jsdom = require('jsdom'),
-    md = require('html-md'),
+    jsdom = require("jsdom/lib/old-api.js"),
+    Europa = require('node-europa'),
+    europa = new Europa(),
     config = {};
 
 // TODO make user-configurable
@@ -16,7 +17,7 @@ function toMarkdown(error, win) {
         console.error('ERROR: Cannot process HTML' + (config.fromURL || ''));
         console.error(error);
     } else {
-        console.log(md(toHTML(win)));
+        console.log(europa.convert(toHTML(win)));
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   "readmeFilename": "README.md",
   "gitHead": "aa53950c4a26bd484dbee5afe9f4d55eab7d31b0",
   "dependencies": {
-    "optimist": "~0.6.0",
-    "jsdom": "~0.8.10",
-    "html-md": "~3.0.2"
+    "jsdom": "~11.2.0",
+    "node-europa": "^4.0.0",
+    "optimist": "~0.6.1"
   }
 }


### PR DESCRIPTION
Updated dependencies, for jsdom node-gyp was failing under Node 7.
Also html-md was deprecated and renamed Europa.